### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/app/src/main/java/com/mooshim/mooshimeter/common/ThermocoupleHelper.java
+++ b/app/src/main/java/com/mooshim/mooshimeter/common/ThermocoupleHelper.java
@@ -4,6 +4,9 @@ package com.mooshim.mooshimeter.common;
  * Created by First on 3/26/2016.
  */
 public class ThermocoupleHelper {
+
+    private ThermocoupleHelper() {}
+
     // All coefficients from Omega's datasheet:
     // ITS-90 Thermocouple Direct and Inverse Polynomials
     // https://www.omega.com/temperature/Z/pdf/z198-201.pdf

--- a/app/src/main/java/com/mooshim/mooshimeter/common/Util.java
+++ b/app/src/main/java/com/mooshim/mooshimeter/common/Util.java
@@ -55,6 +55,8 @@ import java.util.concurrent.Semaphore;
  */
 public class Util {
 
+    private Util() {}
+
     private final static String TAG = "UTIL";
 
     private static Context mContext = null;
@@ -490,6 +492,7 @@ public class Util {
     }
 
     public static class TemperatureUnitsHelper {
+        private TemperatureUnitsHelper() {}
         public static float AbsK2C(float K) {
             return (float) (K-273.15);
         }
@@ -507,6 +510,7 @@ public class Util {
     // Functions for dealing with persistent global preferences
     //////////////////
     public static class preference_keys {
+        private preference_keys() {}
         public static String
         USE_FAHRENHEIT= "USE_FAHRENHEIT";
     }

--- a/app/src/main/java/com/mooshim/mooshimeter/devices/BLEDeviceBase.java
+++ b/app/src/main/java/com/mooshim/mooshimeter/devices/BLEDeviceBase.java
@@ -43,6 +43,7 @@ public class BLEDeviceBase {
      */
 
     public static final class mServiceUUIDs {
+        private mServiceUUIDs() {}
         public final static UUID
         METER_SERVICE      = fromString("1BC5FFA0-0200-62AB-E411-F254E005DBD4"),
         OAD_SERVICE_UUID   = fromString("1BC5FFC0-0200-62AB-E411-F254E005DBD4");
@@ -116,6 +117,7 @@ public class BLEDeviceBase {
     ////////////////////////////////
 
     public static final class mPreferenceKeys {
+        private mPreferenceKeys() {}
         public static final String
                 AUTOCONNECT = "AUTOCONNECT",
                 SKIP_UPGRADE= "SKIP_UPGRADE";

--- a/app/src/main/java/com/mooshim/mooshimeter/devices/ConfigTree.java
+++ b/app/src/main/java/com/mooshim/mooshimeter/devices/ConfigTree.java
@@ -32,6 +32,7 @@ public class ConfigTree {
     private static String TAG = "ConfigTree";
 
     public static class NTYPE {
+        private NTYPE() {}
         public static final byte NOTSET  =-1 ; // May be an informational node, or a choice in a chooser
         public static final byte PLAIN   =0 ; // May be an informational node, or a choice in a chooser
         public static final byte LINK    =1 ; // A link to somewhere else in the tree

--- a/app/src/main/java/com/mooshim/mooshimeter/devices/LegacyMooshimeterDevice.java
+++ b/app/src/main/java/com/mooshim/mooshimeter/devices/LegacyMooshimeterDevice.java
@@ -49,6 +49,7 @@ public class LegacyMooshimeterDevice extends MooshimeterDeviceBase {
      */
 
     public static class mUUID {
+        private mUUID() {}
         public final static UUID
                 METER_SERVICE      = fromString("1BC5FFA0-0200-62AB-E411-F254E005DBD4"),
                 METER_INFO         = fromString("1BC5FFA1-0200-62AB-E411-F254E005DBD4"),

--- a/app/src/main/java/com/mooshim/mooshimeter/devices/MooshimeterDevice.java
+++ b/app/src/main/java/com/mooshim/mooshimeter/devices/MooshimeterDevice.java
@@ -31,6 +31,7 @@ public class MooshimeterDevice extends MooshimeterDeviceBase{
     and the METER_ fields are only accessible when connected in meter mode.
      */
     public static class mUUID {
+        private mUUID() {}
         public final static UUID
             METER_SERVICE       = fromString("1BC5FFA0-0200-62AB-E411-F254E005DBD4"),
             METER_SERIN         = fromString("1BC5FFA1-0200-62AB-E411-F254E005DBD4"),


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.

Faisal Hameed
