### PR TITLE
Code quality fix - Method names should comply with a naming convention.

### DIFF
--- a/app/src/main/java/com/mooshim/mooshimeter/activities/DeviceActivity.java
+++ b/app/src/main/java/com/mooshim/mooshimeter/activities/DeviceActivity.java
@@ -6,14 +6,12 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.graphics.drawable.Drawable;
-import android.graphics.drawable.GradientDrawable;
 import android.os.Bundle;
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
 import android.text.style.RelativeSizeSpan;
 import android.util.Log;
 import android.util.TypedValue;
-import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -267,15 +265,15 @@ public class DeviceActivity extends MyActivity implements MooshimeterDelegate {
         runOnUiThread(new Runnable() {
             @Override
             public void run() {
-                rate_button_refresh();
-                depth_button_refresh();
-                logging_button_refresh();
-                graph_button_refresh();
+                rateButtonRefresh();
+                depthButtonRefresh();
+                loggingButtonRefresh();
+                graphButtonRefresh();
                 for (int c = 0; c < 2; c++) {
-                    input_set_button_refresh(c);
-                    range_button_refresh(c);
-                    sound_button_refresh(c);
-                    zero_button_refresh(c, mMeter.getOffset(chanEnum(c)));
+                    inputSetButtonRefresh(c);
+                    rangeButtonRefresh(c);
+                    soundButtonRefresh(c);
+                    zeroButtonRefresh(c, mMeter.getOffset(chanEnum(c)));
                 }
             }
         });
@@ -345,25 +343,25 @@ public class DeviceActivity extends MyActivity implements MooshimeterDelegate {
             }
         });
     }
-    private void math_label_refresh(final MeterReading val) {
+    private void mathLabelRefresh(final MeterReading val) {
         Util.setText(power_label,val.toString());
         Util.setText(power_button, mMeter.getSelectedDescriptor(MooshimeterControlInterface.Channel.MATH).name);
     }
-    private void math_button_refresh() {
-        math_label_refresh(mMeter.getValue(MooshimeterControlInterface.Channel.MATH));
+    private void mathButtonRefresh() {
+        mathLabelRefresh(mMeter.getValue(MooshimeterControlInterface.Channel.MATH));
     }
-    private void graph_button_refresh() {}
-    private void rate_button_refresh() {
+    private void graphButtonRefresh() {}
+    private void rateButtonRefresh() {
         int rate = mMeter.getSampleRateHz();
         String title = String.format("%dHz", rate);
         autoButtonRefresh(rate_button, title, mMeter.rate_auto);
     }
-    private void depth_button_refresh() {
+    private void depthButtonRefresh() {
         int depth = mMeter.getBufferDepth();
         String title = String.format("%dsmpl", depth);
         autoButtonRefresh(depth_button, title, mMeter.depth_auto);
     }
-    private void logging_button_refresh() {
+    private void loggingButtonRefresh() {
         int s = mMeter.getLoggingStatus();
         final String title;
         final boolean logging_ok = s==0;
@@ -379,11 +377,11 @@ public class DeviceActivity extends MyActivity implements MooshimeterDelegate {
             }
         });
     }
-    private void input_set_button_refresh(final int c) {
+    private void inputSetButtonRefresh(final int c) {
         final String s = mMeter.getInputLabel(chanEnum(c));
         Util.setText(input_set_buttons[c], s);
     }
-    private void range_button_refresh(final int c) {
+    private void rangeButtonRefresh(final int c) {
         String lval = "";
         lval = mMeter.getRangeLabel(chanEnum(c));
         autoButtonRefresh(range_buttons[c], lval, mMeter.range_auto.get(chanEnum(c)));
@@ -393,7 +391,7 @@ public class DeviceActivity extends MyActivity implements MooshimeterDelegate {
         final String label_text = val.toString();
         Util.setText(v, label_text);
     }
-    private void zero_button_refresh (final int c, MeterReading value) {
+    private void zeroButtonRefresh(final int c, MeterReading value) {
         Log.i(TAG,"zerorefresh");
         final String s;
         if(value.value == 0.0) {
@@ -404,7 +402,7 @@ public class DeviceActivity extends MyActivity implements MooshimeterDelegate {
         }
         Util.setText(zero_buttons[c], s);
     }
-    private void sound_button_refresh(final int c) {
+    private void soundButtonRefresh(final int c) {
         Log.i(TAG,"soundrefresh");
         final Button b = sound_buttons[c];
         final String s = "SOUND:"+(mMeter.speech_on.get(chanEnum(c))?"ON":"OFF");
@@ -467,8 +465,8 @@ public class DeviceActivity extends MyActivity implements MooshimeterDelegate {
             mMeter.speech_on.put(chanEnum(c == 0 ? 1 : 0), false);
             mMeter.speech_on.put(chanEnum(c),true);
         }
-        sound_button_refresh(0);
-        sound_button_refresh(1);
+        soundButtonRefresh(0);
+        soundButtonRefresh(1);
     }
 
     public void onCh1InputSetClick(View v) {
@@ -567,7 +565,7 @@ public class DeviceActivity extends MyActivity implements MooshimeterDelegate {
                 runOnUiThread(new Runnable() {
                     @Override
                     public void run() {
-                        math_button_refresh();
+                        mathButtonRefresh();
                     }
                 });
             }
@@ -620,7 +618,7 @@ public class DeviceActivity extends MyActivity implements MooshimeterDelegate {
                 }
                 break;
             case MATH:
-                math_label_refresh(val);
+                mathLabelRefresh(val);
                 break;
         }
     }
@@ -631,26 +629,26 @@ public class DeviceActivity extends MyActivity implements MooshimeterDelegate {
     }
     @Override
     public void onSampleRateChanged(int i, int sample_rate_hz) {
-        rate_button_refresh();
+        rateButtonRefresh();
     }
     @Override
     public void onBufferDepthChanged(int i, int buffer_depth) {
-        depth_button_refresh();
+        depthButtonRefresh();
     }
     @Override
     public void onLoggingStatusChanged(boolean on, int new_state, String message) {
-        logging_button_refresh();
+        loggingButtonRefresh();
     }
     @Override
     public void onRangeChange(MooshimeterControlInterface.Channel c, MooshimeterDeviceBase.RangeDescriptor new_range) {
-        range_button_refresh(c.ordinal());
+        rangeButtonRefresh(c.ordinal());
     }
     @Override
     public void onInputChange(MooshimeterControlInterface.Channel c, MooshimeterDeviceBase.InputDescriptor descriptor) {
-        input_set_button_refresh(c.ordinal());
+        inputSetButtonRefresh(c.ordinal());
     }
     @Override
     public void onOffsetChange(MooshimeterControlInterface.Channel c, MeterReading offset) {
-        zero_button_refresh(c.ordinal(),offset);
+        zeroButtonRefresh(c.ordinal(), offset);
     }
 }

--- a/app/src/main/java/com/mooshim/mooshimeter/common/Util.java
+++ b/app/src/main/java/com/mooshim/mooshimeter/common/Util.java
@@ -140,7 +140,7 @@ public class Util {
         main_dispatcher.dispatch(r);
     }
 
-    public static void dispatch_cb(Runnable r) {
+    public static void dispatchCb(Runnable r) {
         cb_dispatcher.dispatch(r);
     }
     public static boolean onCBThread() {
@@ -490,16 +490,16 @@ public class Util {
     }
 
     public static class TemperatureUnitsHelper {
-        public static float AbsK2C(float K) {
+        public static float absK2C(float K) {
             return (float) (K-273.15);
         }
-        public static float AbsK2F(float K) {
+        public static float absK2F(float K) {
             return (float) ((K - 273.15)* 1.8000 + 32.00);
         }
-        public static float AbsC2F(float C) {
+        public static float absC2F(float C) {
             return (float) ((C)* 1.8000 + 32.00);
         }
-        public static float RelK2F(float C) {
+        public static float aelK2F(float C) {
             return (float) ((C)* 1.8000);
         }
     }

--- a/app/src/main/java/com/mooshim/mooshimeter/devices/LegacyMeterStructure.java
+++ b/app/src/main/java/com/mooshim/mooshimeter/devices/LegacyMeterStructure.java
@@ -35,7 +35,7 @@ public abstract class LegacyMeterStructure {
             return;
         }
         try {
-            unpack_inner(in);
+            unpackInner(in);
         }
         catch(BufferUnderflowException e){
             Log.e(TAG,"Received incorrect pack length while unpacking!");
@@ -96,7 +96,7 @@ public abstract class LegacyMeterStructure {
      * Interpret a BLE payload and set the instance members
      * @param in A byte[] received as a BLE payload
      */
-    public abstract void unpack_inner(byte[] in);
+    public abstract void unpackInner(byte[] in);
 
     /**
      *

--- a/app/src/main/java/com/mooshim/mooshimeter/devices/LegacyMooshimeterDevice.java
+++ b/app/src/main/java/com/mooshim/mooshimeter/devices/LegacyMooshimeterDevice.java
@@ -32,7 +32,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -202,7 +201,7 @@ public class LegacyMooshimeterDevice extends MooshimeterDeviceBase {
         }
 
         @Override
-        public void unpack_inner(byte[] in) {
+        public void unpackInner(byte[] in) {
             ByteBuffer b = wrap(in);
 
             present_meter_state = b.get();
@@ -246,7 +245,7 @@ public class LegacyMooshimeterDevice extends MooshimeterDeviceBase {
         }
 
         @Override
-        public void unpack_inner(byte[] in) {
+        public void unpackInner(byte[] in) {
             ByteBuffer b = wrap(in);
 
             sd_present              = b.get();
@@ -281,7 +280,7 @@ public class LegacyMooshimeterDevice extends MooshimeterDeviceBase {
         }
 
         @Override
-        public void unpack_inner(byte[] in) {
+        public void unpackInner(byte[] in) {
             ByteBuffer b = wrap(in);
             b.order(ByteOrder.LITTLE_ENDIAN);
             pcb_version      = b.get();
@@ -310,7 +309,7 @@ public class LegacyMooshimeterDevice extends MooshimeterDeviceBase {
         }
 
         @Override
-        public void unpack_inner(byte[] in) {
+        public void unpackInner(byte[] in) {
             ByteBuffer b = wrap(in);
 
             reading_lsb[0] = getInt24(b);
@@ -330,7 +329,7 @@ public class LegacyMooshimeterDevice extends MooshimeterDeviceBase {
             return name.getBytes();
         }
         @Override
-        public void unpack_inner(final byte[] in) {
+        public void unpackInner(final byte[] in) {
             name = new String(in);
         }
     }
@@ -347,7 +346,7 @@ public class LegacyMooshimeterDevice extends MooshimeterDeviceBase {
             return b.array();
         }
         @Override
-        public void unpack_inner(final byte[] in) {
+        public void unpackInner(final byte[] in) {
             ByteBuffer b = wrap(in);
             utc_time = b.getInt();
             // Prevent sign extension since Java will assume the int being unpacked is signed
@@ -369,7 +368,7 @@ public class LegacyMooshimeterDevice extends MooshimeterDeviceBase {
             return null;
         }
         @Override
-        public void unpack_inner(byte[] arg) {
+        public void unpackInner(byte[] arg) {
             // Nasty synchonization hack
             meter_ch2_buf.buf_i = 0;
             final int nBytes = getBufferDepth()*3;
@@ -411,7 +410,7 @@ public class LegacyMooshimeterDevice extends MooshimeterDeviceBase {
             return null;
         }
         @Override
-        public void unpack_inner(byte[] arg) {
+        public void unpackInner(byte[] arg) {
             // Nasty synchonization hack
             meter_ch1_buf.buf_i = 0;
             final int nBytes = getBufferDepth()*3;
@@ -795,7 +794,7 @@ public class LegacyMooshimeterDevice extends MooshimeterDeviceBase {
                 float internal_temp = getValue(Channel.CH2).value;
                 MeterReading rval;
                 if(Util.getPreference(Util.preference_keys.USE_FAHRENHEIT)) {
-                    rval = new MeterReading(internal_temp+Util.TemperatureUnitsHelper.RelK2F(delta),5,2000,"F");
+                    rval = new MeterReading(internal_temp+Util.TemperatureUnitsHelper.aelK2F(delta),5,2000,"F");
                 } else {
                     rval = new MeterReading(internal_temp+delta,5,1000,"C");
                 }
@@ -1393,14 +1392,14 @@ public class LegacyMooshimeterDevice extends MooshimeterDeviceBase {
             // Nobody likes Kelvin!  C or F?
             if(Util.getPreference(Util.preference_keys.USE_FAHRENHEIT)) {
                 if(relative) {
-                    rval = new MeterReading(Util.TemperatureUnitsHelper.RelK2F(val),
+                    rval = new MeterReading(Util.TemperatureUnitsHelper.aelK2F(val),
                                             (int)Math.log10(Math.pow(2.0, enob)),
-                                            Util.TemperatureUnitsHelper.RelK2F(max),
+                                            Util.TemperatureUnitsHelper.aelK2F(max),
                                             "F");
                 } else {
-                    rval = new MeterReading(Util.TemperatureUnitsHelper.AbsK2F(val),
+                    rval = new MeterReading(Util.TemperatureUnitsHelper.absK2F(val),
                                             (int) Math.log10(Math.pow(2.0, enob)),
-                                            Util.TemperatureUnitsHelper.AbsK2F(max),
+                                            Util.TemperatureUnitsHelper.absK2F(max),
                                             "F");
                 }
             } else {
@@ -1410,9 +1409,9 @@ public class LegacyMooshimeterDevice extends MooshimeterDeviceBase {
                                             max,
                                             "C");
                 } else {
-                    rval = new MeterReading(Util.TemperatureUnitsHelper.AbsK2C(val),
+                    rval = new MeterReading(Util.TemperatureUnitsHelper.absK2C(val),
                                             (int)Math.log10(Math.pow(2.0, enob)),
-                                            Util.TemperatureUnitsHelper.AbsK2C(max),
+                                            Util.TemperatureUnitsHelper.absK2C(max),
                                             "C");
                 }
             }

--- a/app/src/main/java/com/mooshim/mooshimeter/devices/MooshimeterDevice.java
+++ b/app/src/main/java/com/mooshim/mooshimeter/devices/MooshimeterDevice.java
@@ -10,7 +10,6 @@ import com.mooshim.mooshimeter.common.Util;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -212,14 +211,14 @@ public class MooshimeterDevice extends MooshimeterDeviceBase{
         if(id.units.equals("K")) {
             // Nobody likes Kelvin!  C or F?
             if(Util.getPreference(Util.preference_keys.USE_FAHRENHEIT)) {
-                rval = new MeterReading(Util.TemperatureUnitsHelper.AbsK2F(val),
+                rval = new MeterReading(Util.TemperatureUnitsHelper.absK2F(val),
                                         (int)Math.log10(Math.pow(2.0, enob)),
-                                        Util.TemperatureUnitsHelper.AbsK2F(max),
+                                        Util.TemperatureUnitsHelper.absK2F(max),
                                         "F");
             } else {
-                rval = new MeterReading(Util.TemperatureUnitsHelper.AbsK2C(val),
+                rval = new MeterReading(Util.TemperatureUnitsHelper.absK2C(val),
                                         (int)Math.log10(Math.pow(2.0, enob)),
-                                        Util.TemperatureUnitsHelper.AbsK2C(max),
+                                        Util.TemperatureUnitsHelper.absK2C(max),
                                         "C");
             }
         } else {
@@ -363,7 +362,7 @@ public class MooshimeterDevice extends MooshimeterDeviceBase{
                 float internal_temp = getValue(Channel.CH2).value;
                 MeterReading rval;
                 if(Util.getPreference(Util.preference_keys.USE_FAHRENHEIT)) {
-                    delta_c = Util.TemperatureUnitsHelper.RelK2F(delta_c);
+                    delta_c = Util.TemperatureUnitsHelper.aelK2F(delta_c);
                     rval = new MeterReading(internal_temp+delta_c,5,2000,"F");
                 } else {
                     rval = new MeterReading(internal_temp+delta_c,5,1000,"C");

--- a/app/src/main/java/com/mooshim/mooshimeter/devices/OADDevice.java
+++ b/app/src/main/java/com/mooshim/mooshimeter/devices/OADDevice.java
@@ -68,7 +68,7 @@ public class OADDevice extends BLEDeviceBase {
         public UUID getUUID() { return mUUID.OAD_IMAGE_IDENTIFY; }
 
         @Override
-        public void unpack_inner(byte[] buf) {
+        public void unpackInner(byte[] buf) {
 
         }
 
@@ -135,7 +135,7 @@ public class OADDevice extends BLEDeviceBase {
         }
 
         @Override
-        public void unpack_inner(byte[] in) {
+        public void unpackInner(byte[] in) {
             ByteBuffer b = wrap(in);
             b.order(ByteOrder.LITTLE_ENDIAN);
             requestedBlock = b.getShort();

--- a/app/src/main/java/com/mooshim/mooshimeter/devices/PeripheralWrapper.java
+++ b/app/src/main/java/com/mooshim/mooshimeter/devices/PeripheralWrapper.java
@@ -36,13 +36,11 @@ import com.mooshim.mooshimeter.common.Util;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 public class PeripheralWrapper {
@@ -177,7 +175,7 @@ public class PeripheralWrapper {
                     if (cb != null) {
                         final byte[] payload = val.clone();
                         final double timestamp = Util.getNanoTime();
-                        Util.dispatch_cb(new Runnable() {
+                        Util.dispatchCb(new Runnable() {
                             @Override
                             public void run() {
                                 cb.onReceived(timestamp, payload);
@@ -209,7 +207,7 @@ public class PeripheralWrapper {
                 synchronized (mConnectionStateCB) {
                     List<Runnable> cbs = mConnectionStateCB.get(mConnectionState);
                     for(Runnable cb : cbs) {
-                        Util.dispatch_cb(cb);
+                        Util.dispatchCb(cb);
                     }
                 }
                 bleStateCondition   .sig();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S00100 - Method names should comply with a naming convention.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S00100

Please let me know if you have any questions.

Faisal Hameed
