### PR TITLE
Code quality fix - Public constants should be declared "static final" rather than merely "final".

### DIFF
--- a/app/src/main/java/com/mooshim/mooshimeter/activities/DeviceActivity.java
+++ b/app/src/main/java/com/mooshim/mooshimeter/activities/DeviceActivity.java
@@ -59,10 +59,10 @@ public class DeviceActivity extends MyActivity implements MooshimeterDelegate {
     private final TextView[] value_labels = new TextView[2];
     private TextView power_label;
 
-    private final Button[] input_set_buttons = {null,null};
-    private final Button[] range_buttons     = {null,null};
-    private final Button[] zero_buttons      = {null,null};
-    private final Button[] sound_buttons     = {null,null};
+    private static final Button[] input_set_buttons = {null,null};
+    private static final Button[] range_buttons     = {null,null};
+    private static final Button[] zero_buttons      = {null,null};
+    private static final Button[] sound_buttons     = {null,null};
 
     private Button rate_button;
     private Button depth_button;

--- a/app/src/main/java/com/mooshim/mooshimeter/activities/GraphingActivity.java
+++ b/app/src/main/java/com/mooshim/mooshimeter/activities/GraphingActivity.java
@@ -77,7 +77,7 @@ public class GraphingActivity extends MyActivity implements GraphingActivityInte
     // BEHAVIOR CONTROL
     ///////////////////////
 
-    final int maxNumberOfPoints = 10000;
+    final static int maxNumberOfPoints = 10000;
     int maxNumberOfPointsOnScreen = 32;
     ChDispModes[] dispModes = new ChDispModes[]{ChDispModes.AUTO, ChDispModes.AUTO};;
     boolean scrollLockOn = true;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1170 - Public constants should be declared "static final" rather than merely "final". 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1170

Please let me know if you have any questions.

Faisal Hameed
