### PR TITLE
Code quality fix - Local Variables should not be declared and then immediately returned or thrown.

### DIFF
--- a/app/src/main/java/com/mooshim/mooshimeter/devices/LegacyMooshimeterDevice.java
+++ b/app/src/main/java/com/mooshim/mooshimeter/devices/LegacyMooshimeterDevice.java
@@ -752,8 +752,7 @@ public class LegacyMooshimeterDevice extends MooshimeterDeviceBase {
             }
             @Override
             public MeterReading calculate() {
-                MeterReading rval = MeterReading.mult(getValue(Channel.CH1),getValue(Channel.CH2));
-                return rval;
+                return MeterReading.mult(getValue(Channel.CH1),getValue(Channel.CH2));
             }
         };
         l.add(mid);
@@ -1445,8 +1444,7 @@ public class LegacyMooshimeterDevice extends MooshimeterDeviceBase {
                 if(id.meterSettingsAreValid()) {
                     return id.calculate();
                 } else {
-                    MeterReading rval = invalid_inputs;
-                    return rval;
+                    return invalid_inputs;
                 }
         }
         return new MeterReading();

--- a/app/src/main/java/com/mooshim/mooshimeter/devices/MooshimeterDevice.java
+++ b/app/src/main/java/com/mooshim/mooshimeter/devices/MooshimeterDevice.java
@@ -313,8 +313,7 @@ public class MooshimeterDevice extends MooshimeterDeviceBase{
             }
             @Override
             public MeterReading calculate() {
-                MeterReading rval = MeterReading.mult(getValue(Channel.CH1),getValue(Channel.CH2));
-                return rval;
+                return MeterReading.mult(getValue(Channel.CH1),getValue(Channel.CH2));
             }
         };
         l.add(mid);
@@ -778,8 +777,7 @@ public class MooshimeterDevice extends MooshimeterDeviceBase{
                 if(id.meterSettingsAreValid()) {
                     return id.calculate();
                 } else {
-                    MeterReading rval = new MeterReading(0,0,0,"INVALID INPUTS");
-                    return rval;
+                    return new MeterReading(0,0,0,"INVALID INPUTS");
                 }
         }
         return new MeterReading();

--- a/app/src/main/java/com/mooshim/mooshimeter/devices/PeripheralWrapper.java
+++ b/app/src/main/java/com/mooshim/mooshimeter/devices/PeripheralWrapper.java
@@ -538,8 +538,7 @@ public class PeripheralWrapper {
         try {
             Method localMethod = mBluetoothGatt.getClass().getMethod("refresh");
             if (localMethod != null) {
-                final boolean b = ((Boolean) localMethod.invoke(mBluetoothGatt)).booleanValue();
-                return b;
+                return ((Boolean) localMethod.invoke(mBluetoothGatt));
             } else {
                 Log.e(TAG, "Unable to wipe the GATT Cache");
             }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1488

Please let me know if you have any questions.

Faisal Hameed
