### PR TITLE
Code quality fix - Array designators "[]" should be on the type, not the variable.

### DIFF
--- a/app/src/main/java/com/mooshim/mooshimeter/common/MeterReading.java
+++ b/app/src/main/java/com/mooshim/mooshimeter/common/MeterReading.java
@@ -78,7 +78,7 @@ public class MeterReading {
             return units;
         }
 
-        final String prefixes[] = new String[]{"n","\u03bc","m","","k","M","G"};
+        final String[] prefixes = new String[]{"n","\u03bc","m","","k","M","G"};
         float lval = value;
         if(Math.abs(lval) > 1.2*max) {
             return "OUT OF RANGE";

--- a/app/src/main/java/com/mooshim/mooshimeter/common/ThermocoupleHelper.java
+++ b/app/src/main/java/com/mooshim/mooshimeter/common/ThermocoupleHelper.java
@@ -8,9 +8,9 @@ public class ThermocoupleHelper {
     // ITS-90 Thermocouple Direct and Inverse Polynomials
     // https://www.omega.com/temperature/Z/pdf/z198-201.pdf
     public static class helper {
-        final double coefficients[];
+        final double[] coefficients;
         final double low,high;
-        public helper(double c[], double low, double high) {
+        public helper(double[] c, double low, double high) {
             coefficients=c;
             this.low=low;
             this.high=high;

--- a/app/src/main/java/com/mooshim/mooshimeter/common/Util.java
+++ b/app/src/main/java/com/mooshim/mooshimeter/common/Util.java
@@ -95,7 +95,7 @@ public class Util {
     }
 
     public static byte[] getFileBlock(short bnum) {
-        final byte rval[] = new byte[OAD_BLOCK_SIZE];
+        final byte[] rval = new byte[OAD_BLOCK_SIZE];
         System.arraycopy(mFileBuffer, bnum*OAD_BLOCK_SIZE, rval, 0, OAD_BLOCK_SIZE);
         return rval;
     }

--- a/app/src/main/java/com/mooshim/mooshimeter/devices/LegacyMooshimeterDevice.java
+++ b/app/src/main/java/com/mooshim/mooshimeter/devices/LegacyMooshimeterDevice.java
@@ -291,8 +291,8 @@ public class LegacyMooshimeterDevice extends MooshimeterDeviceBase {
         }
     }
     public class MeterSample      extends LegacyMeterStructure {
-        public final int   reading_lsb[] = new int[2];
-        public final float reading_ms[]  = new float[2];
+        public final int[]   reading_lsb = new int[2];
+        public final float[] reading_ms  = new float[2];
         public MeterSample(PeripheralWrapper p) {super(p);}
         @Override
         public UUID getUUID() { return mUUID.METER_SAMPLE; }
@@ -937,7 +937,7 @@ public class LegacyMooshimeterDevice extends MooshimeterDeviceBase {
         // For the purposes of figuring out how many digits to display
         // Based on ADS1292 datasheet and some special sauce.
         // And empirical measurement of CH1 (which is super noisy due to chopper)
-        final double base_enob_table[] = {
+        final double[] base_enob_table = {
                 20.10,
                 19.58,
                 19.11,
@@ -945,7 +945,7 @@ public class LegacyMooshimeterDevice extends MooshimeterDeviceBase {
                 17.36,
                 14.91,
                 12.53};
-        final int pga_gain_table[] = {6,1,2,3,4,8,12};
+        final int[] pga_gain_table = {6,1,2,3,4,8,12};
         final int samplerate_setting =meter_settings.adc_settings & ADC_SETTINGS_SAMPLERATE_MASK;
         final int buffer_depth_log2 = meter_settings.calc_settings & METER_CALC_SETTINGS_DEPTH_LOG2;
         double enob = base_enob_table[ samplerate_setting ];

--- a/app/src/main/java/com/mooshim/mooshimeter/devices/MooshimeterDevice.java
+++ b/app/src/main/java/com/mooshim/mooshimeter/devices/MooshimeterDevice.java
@@ -82,7 +82,7 @@ public class MooshimeterDevice extends MooshimeterDeviceBase{
             return String.format("%s",d);
     }
     private String toRangeLabel(float max){
-        final String prefixes[] = new String[]{"n","?","m","","k","M","G"};
+        final String[] prefixes = new String[]{"n","?","m","","k","M","G"};
         int prefix_i = 3;
         while(max >= 1000.0) {
             max /= 1000;
@@ -664,7 +664,7 @@ public class MooshimeterDevice extends MooshimeterDeviceBase{
         // For the purposes of figuring out how many digits to display
         // Based on ADS1292 datasheet and some special sauce.
         // And empirical measurement of CH1 (which is super noisy due to chopper)
-        final double base_enob_table[] = {
+        final double[] base_enob_table = {
                 20.10,
                 19.58,
                 19.11,
@@ -749,7 +749,7 @@ public class MooshimeterDevice extends MooshimeterDeviceBase{
     }
     @Override
     public String getLoggingStatusMessage() {
-        final String messages[] = {
+        final String[] messages = {
                 "OK",
                 "NO_MEDIA",
                 "MOUNT_FAIL",

--- a/app/src/main/java/com/mooshim/mooshimeter/interfaces/MooshimeterDelegate.java
+++ b/app/src/main/java/com/mooshim/mooshimeter/interfaces/MooshimeterDelegate.java
@@ -17,7 +17,7 @@ public interface MooshimeterDelegate {
 
     void onSampleReceived(final double timestamp_utc, final MooshimeterControlInterface.Channel c, final MeterReading val);
 
-    void onBufferReceived(final double timestamp_utc, final MooshimeterControlInterface.Channel c, final float dt, final float val[]);
+    void onBufferReceived(final double timestamp_utc, final MooshimeterControlInterface.Channel c, final float dt, final float[] val);
 
     void onSampleRateChanged(final int i, final int sample_rate_hz);
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1197 - Array designators "[]" should be on the type, not the variable.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1197

Please let me know if you have any questions.

Faisal Hameed
