### PR TITLE
Code quality fix - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.

### DIFF
--- a/app/src/main/java/com/mooshim/mooshimeter/devices/ConfigTree.java
+++ b/app/src/main/java/com/mooshim/mooshimeter/devices/ConfigTree.java
@@ -106,7 +106,7 @@ public class ConfigTree {
         public String getShortName() {
             return name;
         }
-        private void getLongName(StringBuffer rval, String sep) {
+        private void getLongName(StringBuilder rval, String sep) {
             // This is the recursive call
             if(parent!=null) {
                 parent.getLongName(rval, sep);
@@ -116,7 +116,7 @@ public class ConfigTree {
         }
         public String getLongName(String sep) {
             if(cache_longname==null) {
-                StringBuffer rval = new StringBuffer();
+                StringBuilder rval = new StringBuilder();
                 getLongName(rval, sep);
                 // This will have an extra seperator on the end and beginning
                 rval.deleteCharAt(rval.length() - 1);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149

Please let me know if you have any questions.

Faisal Hameed
