### PR TITLE
Defer firmware download until firmware update dialog is opened

### DIFF
--- a/app/src/main/java/com/mooshim/mooshimeter/activities/OADActivity.java
+++ b/app/src/main/java/com/mooshim/mooshimeter/activities/OADActivity.java
@@ -207,8 +207,8 @@ public class OADActivity extends MyActivity {
     }
 
     @Override
-    protected void onResume() {
-        super.onResume();
+    protected void onStart() {
+        super.onStart();
 
         if (mFirmwareFile == null) {
             Util.dispatch(new Runnable() {
@@ -235,7 +235,7 @@ public class OADActivity extends MyActivity {
 
                                 }
 
-                    }
+                            }
 
                     );
                 }
@@ -243,6 +243,11 @@ public class OADActivity extends MyActivity {
         } else {
             unpackFirmwareFileBuffer();
         }
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
     }
 
     @Override

--- a/app/src/main/java/com/mooshim/mooshimeter/activities/OADActivity.java
+++ b/app/src/main/java/com/mooshim/mooshimeter/activities/OADActivity.java
@@ -172,19 +172,9 @@ public class OADActivity extends MyActivity {
                 }
             });
         }
-        mFirmwareFile = Util.getLatestFirmware();
-        updateStartButton();
-        unpackFirmwareFileBuffer();
 
-        // TODO: This is repeated code
-        Util.dispatch(new Runnable() {
-            @Override
-            public void run() {
-                FirmwareFile tmp = FirmwareFile.FirmwareFileFromURL("https://moosh.im/s/f/mooshimeter-firmware-beta.bin");
-                Log.d(TAG,"Successfully downloaded newer firmware file!");
-                Util.download_fw = tmp;
-            }
-        });
+        updateStartButton();
+
     }
 
     @Override
@@ -219,6 +209,40 @@ public class OADActivity extends MyActivity {
     @Override
     protected void onResume() {
         super.onResume();
+
+        if (mFirmwareFile == null) {
+            Util.dispatch(new Runnable() {
+                @Override
+                public void run() {
+                    dispatchToLog("Downloading latest firmware...\n");
+                    // This can take a while, so must be done in the background thread
+                    final FirmwareFile result = Util.downloadLatestFirmware();
+
+                    // This must wait until after the download is finished, so we dispatch it back. Nice.
+                    runOnUiThread(
+                            new Runnable() {
+                                @Override
+                                public void run() {
+                                    if (result != null) {
+                                        dispatchToLog("Successfully downloaded newer firmware file!\n");
+                                    } else {
+                                        dispatchToLog("Download failed.\n");
+                                    }
+
+                                    dispatchToLog("Unpacking firmware...");
+                                    mFirmwareFile = Util.getLatestFirmware();
+                                    unpackFirmwareFileBuffer();
+
+                                }
+
+                    }
+
+                    );
+                }
+            });
+        } else {
+            unpackFirmwareFileBuffer();
+        }
     }
 
     @Override
@@ -636,7 +660,7 @@ public class OADActivity extends MyActivity {
     }
 
     private void displayImageInfo(TextView v) {
-        String s = String.format("Old Build: %d<br/>New Build: %d", mMeter.mBuildTime, mFirmwareFile.getVersion());
+        String s = String.format("Current Build: %d<br/>New Build: %d", mMeter.mBuildTime, mFirmwareFile.getVersion());
         v.setText(Html.fromHtml(s));
     }
 
@@ -671,6 +695,15 @@ public class OADActivity extends MyActivity {
     // Utility
     /////////////////////////////
 
+    private void dispatchToLog(final String s) {
+        runOnUiThread(new Runnable() {
+                          @Override
+                          public void run() {
+                              addToLog(s);
+                          }
+                      }
+        );
+    }
     private void addToLog(final String s) {
         Log.v(TAG,s);
         runOnUiThread(new Runnable() {
@@ -706,8 +739,8 @@ public class OADActivity extends MyActivity {
         displayStats();
 
         // Log
-        mLog.setText("Image Loaded.\n");
-        addToLog("Ready to program device!\n");
+        dispatchToLog("Image Loaded.\n");
+        dispatchToLog("Ready to program device!\n");
 
         updateStartButton();
     }

--- a/app/src/main/java/com/mooshim/mooshimeter/common/FirmwareFile.java
+++ b/app/src/main/java/com/mooshim/mooshimeter/common/FirmwareFile.java
@@ -5,7 +5,9 @@ import android.util.Log;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
+import java.net.SocketTimeoutException;
 import java.net.URL;
+import java.net.URLConnection;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -76,7 +78,12 @@ public class FirmwareFile {
             return;
         }
         try {
-            InputStream stream = url.openStream();
+            URLConnection conn = url.openConnection();
+            conn.setConnectTimeout(5000);
+            conn.setReadTimeout(5000);
+            conn.connect();
+
+            InputStream stream = conn.getInputStream();
             int bytes_read=0;
             int rval;
             while(-1 != (rval=stream.read(mFileBuffer, bytes_read, mFileBuffer.length-bytes_read))) {

--- a/app/src/main/java/com/mooshim/mooshimeter/common/Util.java
+++ b/app/src/main/java/com/mooshim/mooshimeter/common/Util.java
@@ -84,16 +84,6 @@ public class Util {
         };
         speaker = new TextToSpeech(context,speaker_init_listener);
         bundled_fw = FirmwareFile.FirmwareFileFromPath("Mooshimeter.bin");
-        Util.dispatch(new Runnable() {
-            @Override
-            public void run() {
-                FirmwareFile tmp = FirmwareFile.FirmwareFileFromURL("https://moosh.im/s/f/mooshimeter-firmware-beta.bin");
-                if(tmp != null) {
-                    Log.d(TAG,"Successfully downloaded newer firmware file!");
-                    download_fw = tmp;
-                }
-            }
-        });
 
         registerPreferenceListeners();
     }
@@ -110,6 +100,21 @@ public class Util {
         for (SharedPreferences.OnSharedPreferenceChangeListener listener : preference_listeners) {
             getSharedPreferences().registerOnSharedPreferenceChangeListener(listener);
         }
+    }
+
+    public static FirmwareFile downloadLatestFirmware() {
+        if (download_fw == null) {
+            FirmwareFile tmp = FirmwareFile.FirmwareFileFromURL("https://moosh.im/s/f/mooshimeter-firmware-beta.bin");
+            if (tmp != null) {
+                Log.d(TAG, "Successfully downloaded newer firmware file!");
+                download_fw = tmp;
+            } else {
+                Log.d(TAG, "Failed to download newer firmware.");
+                download_fw = null;
+            }
+        }
+
+        return download_fw;
     }
 
     public static FirmwareFile getBundledFW() {


### PR DESCRIPTION
This fixes issue #61, which only appears during website downtime.

The issue can be recreated by adding a delay (not blocking!) connections to moosh.im:443 using a debugging proxy such as Fiddler.